### PR TITLE
Fix index.json generation and integration

### DIFF
--- a/.github/workflows/convertMarkdown.yml
+++ b/.github/workflows/convertMarkdown.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Generate index.json
       run: node scripts/generateIndexJson.js
 
+    - name: Print index.json contents
+      run: cat docs/articles/index.json
+
     - name: Commit changes
       run: |
         git config --global user.name 'github-actions[bot]'

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,16 +29,17 @@
                 const recentArticlesList = document.getElementById('recent-articles-list');
                 const allArticlesList = document.getElementById('all-articles-list');
 
-                data.recent.forEach(article => {
+                data.forEach(article => {
                     const listItem = document.createElement('li');
-                    listItem.innerHTML = `<a href="articles/${article}">${article}</a>`;
-                    recentArticlesList.appendChild(listItem);
+                    listItem.innerHTML = `<a href="${article.path}">${article.title}</a> - ${article.date}`;
+                    allArticlesList.appendChild(listItem);
                 });
 
-                data.all.forEach(article => {
+                const recentArticles = data.slice(0, 5);
+                recentArticles.forEach(article => {
                     const listItem = document.createElement('li');
-                    listItem.innerHTML = `<a href="articles/${article}">${article}</a>`;
-                    allArticlesList.appendChild(listItem);
+                    listItem.innerHTML = `<a href="${article.path}">${article.title}</a> - ${article.date}`;
+                    recentArticlesList.appendChild(listItem);
                 });
             })
             .catch(error => console.error('Error fetching articles:', error));

--- a/scripts/generateIndexJson.js
+++ b/scripts/generateIndexJson.js
@@ -7,17 +7,19 @@ const generateIndexJson = () => {
 
   const articles = fs.readdirSync(articlesDir).filter(file => file.endsWith('.html'));
 
-  const indexData = {
-    recent: articles.slice(-5),
-    all: articles.map(article => {
-      const articlePath = path.join(articlesDir, article);
-      const stats = fs.statSync(articlePath);
-      return {
-        title: article.replace('.html', ''),
-        creationDate: stats.birthtime
-      };
-    })
-  };
+  const indexData = articles.map(article => {
+    const articlePath = path.join(articlesDir, article);
+    const stats = fs.statSync(articlePath);
+    const content = fs.readFileSync(articlePath, 'utf-8');
+    const titleMatch = content.match(/<title>(.*?)<\/title>/);
+    const title = titleMatch ? titleMatch[1] : 'Untitled';
+
+    return {
+      title: title,
+      path: `/docs/articles/${article}`,
+      date: stats.birthtime.toISOString().split('T')[0]
+    };
+  });
 
   fs.writeFileSync(indexFilePath, JSON.stringify(indexData, null, 2), 'utf-8');
 };


### PR DESCRIPTION
Update `scripts/generateIndexJson.js` and GitHub Actions workflow to generate and integrate `index.json` file.

* **scripts/generateIndexJson.js**:
  - Update script to scan `/docs/articles/` folder for all `.html` files.
  - Generate `index.json` file with title, path, and date for each article.
  - Extract titles from the `<title>` tag of each HTML file.

* **.github/workflows/convertMarkdown.yml**:
  - Add step to run `scripts/generateIndexJson.js` after converting Markdown to HTML.
  - Add step to print the contents of `index.json` to verify it is generated correctly.

* **docs/index.html**:
  - Update script to dynamically load and display articles from `index.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JustGibas/Markdown2Experience/pull/4?shareId=88ee9bb6-ea30-49cb-92e6-0e5c63da54cf).